### PR TITLE
Fix scroll with keys and other improvements

### DIFF
--- a/lib/typewriter-editor.coffee
+++ b/lib/typewriter-editor.coffee
@@ -1,0 +1,22 @@
+module.exports =
+  enable: ->
+    @activeItemSubscription = atom.workspace.onDidStopChangingActivePaneItem =>
+      @prepareEditor()
+    @prepareEditor()
+
+  disable: ->
+    @activeItemSubscription?.dispose()
+    @cursorChangePosSubscription?.dispose()
+
+  center: ->
+    halfScreen = Math.floor(@editor.getRowsPerPage() / 2)
+    cursor = @editor.getCursorScreenPosition()
+    position = @editor.getLineHeightInPixels() * (cursor.row - halfScreen)
+    @editorElement.setScrollTop position
+
+  prepareEditor: ->
+    @cursorChangePosSubscription?.dispose()
+    @editor = atom.workspace.getActiveTextEditor()
+    return unless @editor
+    @editorElement = atom.views.getView @editor
+    @cursorChangePosSubscription = @editor.onDidChangeCursorPosition @center.bind(this)

--- a/lib/typewriter-editor.coffee
+++ b/lib/typewriter-editor.coffee
@@ -12,7 +12,8 @@ module.exports =
     halfScreen = Math.floor(@editor.getRowsPerPage() / 2)
     cursor = @editor.getCursorScreenPosition()
     position = @editor.getLineHeightInPixels() * (cursor.row - halfScreen)
-    @editorElement.setScrollTop position
+    # Timeout needed since position changes after ::onDidChangeCursorPosition on moving with keys
+    setTimeout => @editorElement.setScrollTop position, 1
 
   prepareEditor: ->
     @cursorChangePosSubscription?.dispose()

--- a/lib/typewriter-scroll.coffee
+++ b/lib/typewriter-scroll.coffee
@@ -1,8 +1,11 @@
 {CompositeDisposable} = require 'atom'
+typewriterEditor = require "./typewriter-editor"
+
 
 module.exports = TypewriterScroll =
+  typewriterEditor: typewriterEditor
   subscriptions: null
-  lineChanged: null
+  enabled: false
 
   config:
     autoToggle:
@@ -11,29 +14,23 @@ module.exports = TypewriterScroll =
 
   activate: (state) ->
     @subscriptions = new CompositeDisposable
-    @subscriptions.add atom.commands.add 'atom-workspace', 'typewriter-scroll:toggle': => @toggle()
-    @lineChanged?.dispose()
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      "typewriter-scroll:toggle": => @toggle()
     if atom.config.get 'typewriter-scroll.autoToggle'
-      @setEnabled(true)
+      @toggle()
 
   deactivate: ->
+    @enabled = false
     @subscriptions.dispose()
-    @lineChanged?.dispose()
+    @typewriterEditor.disable()
 
-  setEnabled: (value) ->
-    if not value
-      @lineChanged?.dispose()
-      @lineChanged = null
-    else if not @lineChanged
-      editor = atom.workspace.getActiveTextEditor()
-      @lineChanged = editor.onDidChangeCursorPosition ->
-        halfScreen = Math.floor(editor.getRowsPerPage() / 2)
-        cursor = editor.getCursorScreenPosition()
-        element = editor.getElement()
-        element.setScrollTop editor.getLineHeightInPixels() * (cursor.row - halfScreen)
+  disable: ->
+    @enabled = false
+    @typewriterEditor.disable()
+
+  enable: ->
+    @enabled = true
+    @typewriterEditor.enable()
 
   toggle: ->
-    if @lineChanged
-      @setEnabled false
-    else
-      @setEnabled true
+    if @enabled then @disable() else @enable()

--- a/lib/typewriter-scroll.coffee
+++ b/lib/typewriter-scroll.coffee
@@ -4,25 +4,36 @@ module.exports = TypewriterScroll =
   subscriptions: null
   lineChanged: null
 
+  config:
+    autoToggle:
+      type: 'boolean'
+      default: true
+
   activate: (state) ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace', 'typewriter-scroll:toggle': => @toggle()
-
     @lineChanged?.dispose()
+    if atom.config.get 'typewriter-scroll.autoToggle'
+      @setEnabled(true)
 
   deactivate: ->
     @subscriptions.dispose()
     @lineChanged?.dispose()
 
-  toggle: ->
-    editor = atom.workspace.getActiveTextEditor()
-
-    if @lineChanged
-      @lineChanged.dispose()
+  setEnabled: (value) ->
+    if not value
+      @lineChanged?.dispose()
       @lineChanged = null
-    else
+    else if not @lineChanged
+      editor = atom.workspace.getActiveTextEditor()
       @lineChanged = editor.onDidChangeCursorPosition ->
         halfScreen = Math.floor(editor.getRowsPerPage() / 2)
         cursor = editor.getCursorScreenPosition()
         element = editor.getElement()
         element.setScrollTop editor.getLineHeightInPixels() * (cursor.row - halfScreen)
+
+  toggle: ->
+    if @lineChanged
+      @setEnabled false
+    else
+      @setEnabled true

--- a/lib/typewriter-scroll.coffee
+++ b/lib/typewriter-scroll.coffee
@@ -16,6 +16,8 @@ module.exports = TypewriterScroll =
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace',
       "typewriter-scroll:toggle": => @toggle()
+      "typewriter-scroll:enable": => @enable()
+      "typewriter-scroll:disable": => @disable()
     if atom.config.get 'typewriter-scroll.autoToggle'
       @toggle()
 

--- a/menus/typewriter-scroll.cson
+++ b/menus/typewriter-scroll.cson
@@ -3,7 +3,7 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'typewriter-scroll'
+      'label': 'Typewriter Scroll'
       'submenu': [
         {
           'label': 'Toggle'

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "scrolling",
     "writing"
   ],
-  "activationCommands": {
-    "atom-workspace": "typewriter-scroll:toggle"
-  },
   "repository": "https://github.com/farcaller/typewriter-scroll",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Typewritter scroll with keys
It seems that at some point `setTopScroll` changed its behavior and doesn't update when moving with arrow keys. The same behavior as in https://github.com/defunkt/Zen. Apparently, there's something resetting the scroll position after `::onDidChangeCursorPosition`. Probably not the prettiest solution, but I fixed it by adding a small timeout.

## Global toggle
Now, if `typewriter-scroll` is toggled, it applies to all panes. Also, I added auto toggle in the config.